### PR TITLE
Add GodMode9 Discord link

### DIFF
--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -4,7 +4,7 @@ title: "GodMode9 Usage"
 
 {% include toc title="Table of Contents" %}
 
-For support for GodMode9, as well as help with scripting and to get updates and info, join the <a href="https://discord.gg/EGu6Qxw">GodMode9 Discord Server</a>
+For support with GodMode9, as well as help with scripting and to get updates and info, join the [GodMode9 Discord server](https://discord.gg/EGu6Qxw).
 {: .notice--primary}
 
 ### Required Reading

--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -4,6 +4,9 @@ title: "GodMode9 Usage"
 
 {% include toc title="Table of Contents" %}
 
+For support for GodMode9, as well as help with scripting and to get updates and info, join the <a href="https://discord.gg/EGu6Qxw">GodMode9 Discord Server</a>
+{: .notice--primary}
+
 ### Required Reading
 
 GodMode9 is a full access file browser for the Nintendo 3DS console, giving you access to your SD card, the FAT partitions inside your SysNAND and EmuNAND, and basically anything else. Among other functionality, you can copy, delete, rename files, and create folders.


### PR DESCRIPTION
I added the GodMode9 Discord link to `/godmode9-usage`. I'm very sure that it'll look correct, but I can't be sure since I have no way of visualizing it (trying to publish it under https://sirnapkin1334.github.io/Guide_3DS/ causes it to lose CSS or something of the like). If you could visualize it to make sure that I added it correctly, that would be good.