### PR TITLE
Hold power last for ntrboot

### DIFF
--- a/_pages/en_US/installing-boot9strap-(ntrboot).txt
+++ b/_pages/en_US/installing-boot9strap-(ntrboot).txt
@@ -45,7 +45,7 @@ To extract the `.7z` files linked on this page, you will need a file archiver li
 1. Insert your flashcart into your device
 1. Place the magnet on your device to trigger the sleep sensor
   + On old 2DS, you should instead enable the sleep mode switch
-1. Hold (Power) + (Start) + (Select) + (X) for several seconds, then release the buttons
+1. Hold (Start) + (Select) + (X) + (Power) for several seconds, then release the buttons
   + It may take a few attempts to get this to work because the positioning is awkward
 1. If the exploit was successful, you will have booted into SafeB9SInstaller
 


### PR DESCRIPTION
Since ntrboot technically looks for start+select+x after you press power and if you hold power first and take too long it doesnt register