### PR TITLE
Be less specific about the name of backup.bin

### DIFF
--- a/_pages/en_US/installing-boot9strap-(ntrboot).txt
+++ b/_pages/en_US/installing-boot9strap-(ntrboot).txt
@@ -125,7 +125,7 @@ Do not follow this section until you have completed the rest of the instructions
 1. Insert your SD card into your computer
   + This is the SD card from your 3DS, *not* the SD card from your flashcart
 1. Create a folder named `ntrboot` on the root of your SD card
-1. Copy `backup.bin` from your flashrom backup `.zip` to the `/ntrboot/` folder on the root of your SD card
+1. Copy the `.bin` file from your flashrom backup `.zip` to the `/ntrboot/` folder on the root of your SD card
 1. Create a folder named `payloads` in the `luma` folder on your SD card 
 1. Copy `ntrboot_flasher.firm` to the `/luma/payloads/` folder on your SD card
 1. Reinsert your SD card into your device


### PR DESCRIPTION
Recent ntrboot_flasher versions and flashrom backups don't actually look for a file named `backup.bin` only anymore but look for a `flashcartname-backup.bin` file instead and some people think they have the wrong file