### PR TITLE
adds step to ensure user remounts SD card before moving to next section

### DIFF
--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -135,6 +135,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
   + These backups will save you from a brick and/or help you recover files from the NAND image if anything goes wrong in the future
 1. Delete `<date>_<serialnumber>_sysnand_###.bin` and `<date>_<serialnumber>_sysnand_###.bin.sha` from the `/gm9/out/` folder on your SD card after copying it
 1. Reinsert your SD card into your device
+1. Hold (R) and press (B) at the same time to remount your SD card
 
 #### Section VIII - Cleanup SD Card
 


### PR DESCRIPTION
Encountered a file-not-found error at step 2 below, because SD card needed to be remounted.

#### Section VIII - Cleanup SD Card
  1.  Press (Home) to bring up the action menu
  2. Select “Scripts…”
  ...